### PR TITLE
Removed bang operators from optional parameters

### DIFF
--- a/lib/postgres_pool.dart
+++ b/lib/postgres_pool.dart
@@ -588,7 +588,7 @@ class PgPool implements PostgreSQLExecutionContext {
     return run(
       (c) => c.execute(
         fmtString,
-        substitutionValues: substitutionValues!,
+        substitutionValues: substitutionValues,
         timeoutInSeconds: timeoutInSeconds,
       ),
       sessionId: sessionId,
@@ -613,9 +613,9 @@ class PgPool implements PostgreSQLExecutionContext {
     return run(
       (c) => c.mappedResultsQuery(
         fmtString,
-        substitutionValues: substitutionValues!,
+        substitutionValues: substitutionValues,
         allowReuse: allowReuse,
-        timeoutInSeconds: timeoutInSeconds!,
+        timeoutInSeconds: timeoutInSeconds,
       ),
       sessionId: sessionId,
       traceId: traceId,
@@ -731,7 +731,7 @@ class _PgExecutionContextWrapper implements PostgreSQLExecutionContext {
     return _run(
       () => _delegate.query(
         fmtString,
-        substitutionValues: substitutionValues!,
+        substitutionValues: substitutionValues,
         allowReuse: allowReuse,
         timeoutInSeconds: timeoutInSeconds,
       ),
@@ -749,9 +749,9 @@ class _PgExecutionContextWrapper implements PostgreSQLExecutionContext {
     return _run(
       () => _delegate.mappedResultsQuery(
         fmtString,
-        substitutionValues: substitutionValues!,
+        substitutionValues: substitutionValues,
         allowReuse: allowReuse,
-        timeoutInSeconds: timeoutInSeconds!,
+        timeoutInSeconds: timeoutInSeconds,
       ),
       fmtString,
       substitutionValues,


### PR DESCRIPTION
Fixes the below null safety error:

```
Null check operator used on a null value\npackage:postgres_pool/postgres_pool.dart 
734  _PgExecutionContextWrapper.query.<fn>\npackage:postgres_pool/postgres_pool.dart 
678  _PgExecutionContextWrapper._run\npackage:postgres_pool/postgres_pool.dart 
731  _PgExecutionContextWrapper.query\npackage:os_cf_test/functions.dart 
34          function.<fn>\npackage:os_cf_test/functions.dart 
33          function.<fn>\npackage:postgres_pool/postgres_pool.dart 
319  PgPool.run.<fn>.<fn>\npackage:postgres_pool/postgres_pool.dart 
418  PgPool._useOrCreate\npackage:postgres_pool/postgres_pool.dart 
390  PgPool._withConnection.<fn>\npackage:executor/src/executor_impl.dart 
61    _Executor.scheduleTask\npackage:postgres_pool/postgres_pool.dart 
318  PgPool.run.<fn>\npackage:retry/retry.dart 
131                  RetryOptions.retry\npackage:postgres_pool/postgres_pool.dart 
316  PgPool.run\npackage:os_cf_test/functions.dart 
33          function\n===== asynchronous gap ===========================\n
package:postgres_pool/postgres_pool.dart 
318  PgPool.run.<fn>\npackage:retry/retry.dart 
131                  RetryOptions.retry\npackage:postgres_pool/postgres_pool.dart
 316  PgPool.run\npackage:os_cf_test/functions.dart 
33          function
```