### PR TITLE
Fix for 'Concurrent modification during iteration'

### DIFF
--- a/lib/postgres_pool.dart
+++ b/lib/postgres_pool.dart
@@ -392,7 +392,7 @@ class PgPool implements PostgreSQLExecutionContext {
   Future close() async {
     await _executor.close();
     while (_connections.isNotEmpty) {
-      await Future.wait(_connections.map(_close));
+      await Future.wait(List.of(_connections).map(_close));
     }
     await _events.close();
   }


### PR DESCRIPTION
Line 395 is modifying the list while iterating through it causing:

Concurrent modification during iteration: Instance of 'MappedListIterable<_ConnectionCtx, Future<dynamic>>'.

Fixed by passing a copy of _connections.